### PR TITLE
feat: add DEV_DEFAULT_API_KEY to K8s secret

### DIFF
--- a/deployment/kubernetes/secret.yaml
+++ b/deployment/kubernetes/secret.yaml
@@ -12,3 +12,4 @@ data:
   JWT_SECRET_KEY: ""  # REQUIRED: Add your JWT secret key here (base64 encoded)
   DEEPLAKE_TOKEN: ""  # Add your Deep Lake token here (base64 encoded)
   DEEPLAKE_ORG_ID: ""  # Add your Deep Lake org ID here (base64 encoded)
+  DEV_DEFAULT_API_KEY: ""  # Default API key for internal service auth (base64 encoded, must match DEEPLAKE_API_KEY on agent-builder)


### PR DESCRIPTION
## Summary
- Add `DEV_DEFAULT_API_KEY` placeholder to K8s secret manifest for internal service auth between agent-builder and deeplake-api

## Test plan
- [x] DeepLake health endpoint accessible with API key from agent-builder pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)